### PR TITLE
feat: Migrate microservices to Knative

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,40 @@
+## Installation and Testing Instructions
+
+### Prerequisites
+
+* A running Kubernetes cluster (e.g., Minikube, a cloud-based cluster).
+* `kubectl` configured to communicate with your cluster.
+* Knative Serving and Kourier installed on your cluster.
+
+### Deployment
+
+1.  **Deploy MongoDB:**
+    ```bash
+    kubectl apply -f k8s/mongo-deployment.yaml
+    ```
+
+2.  **Deploy the microservices:**
+    ```bash
+    kubectl apply -f k8s/api-get-books.yaml
+    kubectl apply -f k8s/api-post-books.yaml
+    kubectl apply -f k8s/api-put-books.yaml
+    kubectl apply -f k8s/api-delete-books.yaml
+    kubectl apply -f k8s/frontend-renderer.yaml
+    ```
+
+### Testing
+
+1.  **Get the URL of the frontend service:**
+    ```bash
+    kubectl get ksvc frontend-renderer
+    ```
+    The output will show the URL of the service.
+
+2.  **Access the application:**
+    Open the URL in your browser. You should see the book store application.
+
+3.  **Test the API endpoints:**
+    You can use `curl` or a tool like Postman to test the API endpoints. The URLs for the API services can be retrieved using `kubectl get ksvc`. For example, to get the URL for the `api-get-books` service:
+    ```bash
+    kubectl get ksvc api-get-books
+    ```

--- a/k8s/api-delete-books.yaml
+++ b/k8s/api-delete-books.yaml
@@ -1,0 +1,14 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: api-delete-books
+spec:
+  template:
+    spec:
+      containers:
+      - image: marinazhdanova/bookstore-api_delete_books:latest
+        ports:
+        - containerPort: 3004
+        env:
+        - name: DATABASE_URI
+          value: "mongodb://mongodb:testmongo@mongo:27017/exercise-1?authSource=admin"

--- a/k8s/api-get-books.yaml
+++ b/k8s/api-get-books.yaml
@@ -1,0 +1,14 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: api-get-books
+spec:
+  template:
+    spec:
+      containers:
+      - image: marinazhdanova/bookstore-api_get_books:latest
+        ports:
+        - containerPort: 3001
+        env:
+        - name: DATABASE_URI
+          value: "mongodb://mongodb:testmongo@mongo:27017/exercise-1?authSource=admin"

--- a/k8s/api-post-books.yaml
+++ b/k8s/api-post-books.yaml
@@ -1,0 +1,14 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: api-post-books
+spec:
+  template:
+    spec:
+      containers:
+      - image: marinazhdanova/bookstore-api_post_books:latest
+        ports:
+        - containerPort: 3002
+        env:
+        - name: DATABASE_URI
+          value: "mongodb://mongodb:testmongo@mongo:27017/exercise-1?authSource=admin"

--- a/k8s/api-put-books.yaml
+++ b/k8s/api-put-books.yaml
@@ -1,0 +1,14 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: api-put-books
+spec:
+  template:
+    spec:
+      containers:
+      - image: marinazhdanova/bookstore-api_put_books:latest
+        ports:
+        - containerPort: 3003
+        env:
+        - name: DATABASE_URI
+          value: "mongodb://mongodb:testmongo@mongo:27017/exercise-1?authSource=admin"

--- a/k8s/frontend-renderer.yaml
+++ b/k8s/frontend-renderer.yaml
@@ -1,0 +1,14 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: frontend-renderer
+spec:
+  template:
+    spec:
+      containers:
+      - image: marinazhdanova/bookstore-frontend_renderer:latest
+        ports:
+        - containerPort: 3005
+        env:
+        - name: DATABASE_URI
+          value: "mongodb://mongodb:testmongo@mongo:27017/exercise-1?authSource=admin"

--- a/k8s/mongo-deployment.yaml
+++ b/k8s/mongo-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mongo
+  template:
+    metadata:
+      labels:
+        app: mongo
+    spec:
+      containers:
+      - name: mongo
+        image: mongo:7.0
+        ports:
+        - containerPort: 27017
+        env:
+        - name: MONGO_INITDB_ROOT_USERNAME
+          value: "mongodb"
+        - name: MONGO_INITDB_ROOT_PASSWORD
+          value: "testmongo"
+        volumeMounts:
+        - name: mongo-data
+          mountPath: /data/db
+  volumes:
+  - name: mongo-data
+    emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+spec:
+  selector:
+    app: mongo
+  ports:
+  - protocol: TCP
+    port: 27017
+    targetPort: 27017


### PR DESCRIPTION
This commit introduces the necessary Kubernetes and Knative configurations to deploy the bookstore application on a Knative-enabled Kubernetes cluster.

- A Kubernetes deployment for MongoDB is added.
- Each of the five microservices is converted to a Knative service.
- A README file with deployment and testing instructions is included in the `k8s` directory.